### PR TITLE
west.yml: add missing qcbor to allow list

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -24,6 +24,7 @@ manifest:
           - net-tools
           - nrfxlib
           - segger
+          - qcbor
           - tfm-mcuboot
           - tinycrypt
           - trusted-firmware-m


### PR DESCRIPTION
qcbor is no longer used by the Golioth SDK, but is still needed by some NCS libraries and should be included in the module allow list.