### PR TITLE
workflow: remove aludel mini from automatic builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             matrix:
               ZEPHYR_SDK: [0.16.3]
-              BOARD: ["nrf9160dk/nrf9160/ns","aludel_mini/nrf9160/ns","aludel_elixir/nrf9160/ns"]
+              BOARD: ["nrf9160dk/nrf9160/ns","aludel_elixir/nrf9160/ns"]
 
         uses: ./.github/workflows/build_zephyr.yml
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] 2024-10-03
 
 ### Added
 
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove pre-commit for consistency with the Reference Design Template
+- Remove Aludel Mini (hardware no longer available, replaced by Elixir)
 
 ## [1.2.0] - 2023-09-05
 


### PR DESCRIPTION
The Aludel Mini hardware is no longer available. Remove automatic firmware builds from the release process.